### PR TITLE
fixes crash when adding/removing components from a 'other' context

### DIFF
--- a/ecsact/entt/runtime.hh
+++ b/ecsact/entt/runtime.hh
@@ -677,6 +677,11 @@ private:
 
 					auto& assoc_view = std::get<I>(assoc_views);
 					auto& assoc_view_itr = std::get<I>(assoc_views_itrs);
+					if(assoc_view.begin() == assoc_view.end()) {
+						missing_assoc_entities = true;
+						return;
+					}
+
 					assert(view.contains(entity));
 					auto& comp = view.template get<ComponentT>(entity);
 

--- a/runtime/test/runtime_test.ecsact
+++ b/runtime/test/runtime_test.ecsact
@@ -68,6 +68,7 @@ component AddAssocTestComponent {
 component AddAssocTestTag;
 
 system AddAssocTest {
+	readwrite ComponentA;
 	readwrite OtherEntityComponent with target {
 		include AddAssocTestTag;
 		adds AddAssocTestComponent;

--- a/runtime/test/runtime_test.ecsact
+++ b/runtime/test/runtime_test.ecsact
@@ -61,6 +61,19 @@ action AssocTestAction {
 	adds OtherEntityComponent;
 }
 
+component AddAssocTestComponent {
+	i32 num;
+}
+
+component AddAssocTestTag;
+
+system AddAssocTest {
+	readwrite OtherEntityComponent with target {
+		include AddAssocTestTag;
+		adds AddAssocTestComponent;
+	}
+}
+
 system AttackDamage {
 	readwrite Attacking with target {
 		readwrite Health;


### PR DESCRIPTION
- ~~fix inconsistency with field get using typed vs void~~
- ~~fix crashes caused by interacting with associated components~~

Accidentally re-used a branch for a different issue.

This solves a problem where components added/removed from 'other' contexts were not being properly applied. This also solves an issue where associated system impls run on an empty view causes a crash.
